### PR TITLE
feat: Update navigation bar and add monogram icon

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -46,6 +46,17 @@
             {% if page.permalink == '/' %} {% assign about_title = page.title %} {% endif %}
           {% endfor %}
 
+          <!-- Monogram -->
+          <li class="nav-item">
+            <a class="nav-link" href="{{ '/' | relative_url }}" title="Homepage">
+              {% if site.enable_darkmode %}
+                <img src="assets/img/monogram-light.svg" alt="Homepage" class="img-fluid theme-toggle-light monogram-icon" style="height: 1.5em; margin-top: -0.25em; margin-right: 0.5em;">
+                <img src="assets/img/monogram-dark.svg" alt="Homepage" class="img-fluid theme-toggle-dark monogram-icon" style="height: 1.5em; margin-top: -0.25em; margin-right: 0.5em;">
+              {% else %}
+                <img src="assets/img/monogram-light.svg" alt="Homepage" class="img-fluid monogram-icon" style="height: 1.5em; margin-top: -0.25em; margin-right: 0.5em;">
+              {% endif %}
+            </a>
+          </li>
           <!-- About -->
           <li class="nav-item {% if page.permalink == '/' %}active{% endif %}">
             <a class="nav-link" href="{{ '/' | relative_url }}">

--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -2,7 +2,7 @@
 layout: default
 permalink: /blog/
 title: blog
-nav: true
+nav: false
 nav_order: 1
 pagination:
   enabled: true

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -3,7 +3,7 @@ layout: cv
 permalink: /cv/
 title: cv
 nav: true
-nav_order: 5
+nav_order: 4
 cv_pdf: example_pdf.pdf # you can also use external links here
 description: This is a description of the page. You can modify it in '_pages/cv.md'. You can also change or remove the top pdf download button.
 toc:

--- a/_pages/dropdown.md
+++ b/_pages/dropdown.md
@@ -2,7 +2,7 @@
 layout: page
 title: submenus
 nav: true
-nav_order: 8
+nav_order: 6
 dropdown: true
 children:
   - title: bookshelf
@@ -10,4 +10,6 @@ children:
   - title: divider
   - title: blog
     permalink: /blog/
+  - title: other projects
+    permalink: /projects/
 ---

--- a/_pages/profiles.md
+++ b/_pages/profiles.md
@@ -1,10 +1,10 @@
 ---
 layout: profiles
 permalink: /people/
-title: people
+title: bio
 description: members of the lab or group
 nav: true
-nav_order: 7
+nav_order: 5
 
 profiles:
   # if you want to include more than one profile, just replicate the following block

--- a/_pages/projects.md
+++ b/_pages/projects.md
@@ -1,9 +1,9 @@
 ---
 layout: page
-title: projects
+title: other projects
 permalink: /projects/
 description: A growing collection of your cool projects.
-nav: true
+nav: false
 nav_order: 3
 display_categories: [work, fun]
 horizontal: false

--- a/_pages/repositories.md
+++ b/_pages/repositories.md
@@ -4,7 +4,7 @@ permalink: /repositories/
 title: repositories
 description: Edit the `_data/repositories.yml` and change the `github_users` and `github_repos` lists to include your own GitHub profile and repositories.
 nav: true
-nav_order: 4
+nav_order: 3
 ---
 
 {% if site.data.repositories.github_users %}

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,10 +1,10 @@
 ---
 layout: page
-permalink: /teaching/
-title: teaching
+permalink: /research/
+title: research
 description: Materials for courses you taught. Replace this text with your description.
 nav: true
-nav_order: 6
+nav_order: 2
 ---
 
 For now, this page is assumed to be a static description of your courses. You can convert it to a collection similar to `_projects/` so that you can have a dedicated page for each course.

--- a/_sass/_themes.scss
+++ b/_sass/_themes.scss
@@ -76,6 +76,25 @@
   }
 }
 
+// Monogram theme toggling
+.theme-toggle-light,
+.theme-toggle-dark {
+  display: none; // Initially hide both
+}
+
+html[data-theme='light'] .theme-toggle-light {
+  display: inline-block !important;
+}
+
+html[data-theme='dark'] .theme-toggle-dark {
+  display: inline-block !important;
+}
+
+// Fallback for when system preference is light and no explicit theme is set, or dark mode is off
+// This ensures the light monogram shows by default if dark mode isn't active or enabled.
+// The primary logic is within the html[data-theme='light/dark'] selectors.
+// If site.enable_darkmode is false, the Liquid template only includes the light monogram by default.
+
 html[data-theme="dark"] {
   color-scheme: dark;
   --global-bg-color: #{$grey-color-dark};


### PR DESCRIPTION
This commit implements several changes to the main navigation bar and site structure:

1.  **Monogram Icon Added:**
    *   A theme-aware monogram icon (light/dark) is added to the far left of the toolbar.
    *   It links to the homepage.
    *   Placeholder image paths `assets/img/monogram-light.svg` and `assets/img/monogram-dark.svg` are used.

2.  **Navigation Bar Restructured:**
    *   'blog' button removed from the main toolbar; remains in 'submenus' dropdown.
    *   'teaching' button moved next to 'about' and renamed to 'research'.
    *   'projects' button moved to 'submenus' dropdown and renamed to 'other projects'.
    *   'cv' button moved to the right of 'repositories'.
    *   'people' button renamed to 'bio'.

3.  **File Changes:**
    *   `_includes/header.liquid`: Modified to include monogram HTML.
    *   `_sass/_themes.scss`: Added CSS for monogram theme switching.
    *   `_pages/blog.md`: `nav: false`.
    *   `_pages/teaching.md`: Renamed to `_pages/research.md`, front matter updated (title, permalink, nav_order).
    *   `_pages/projects.md`: Front matter updated (title, nav: false).
    *   `_pages/dropdown.md`: Added 'other projects' to children, `nav_order` updated.
    *   `_pages/cv.md`: `nav_order` updated.
    *   `_pages/profiles.md`: Front matter updated (title, nav_order).
    *   `_pages/repositories.md`: `nav_order` updated.

The navigation now follows the order: Monogram | About | Research | Repositories | CV | Bio | Submenus.
The Submenus dropdown includes: Bookshelf | Divider | Blog | Other Projects.